### PR TITLE
docs: 상품수정/주문생성 API 예시 수정 (3조 피드백 반영)

### DIFF
--- a/docs/api-fix-20260406.md
+++ b/docs/api-fix-20260406.md
@@ -1,0 +1,100 @@
+# GentleLion API 문서 수정 안내 (2026-04-06)
+
+> 3조 피드백 반영: 상품 수정, 주문 생성 API의 Try it 예시 수정
+
+---
+
+## 변경 사항
+
+### 1. 상품 수정 (PUT /admin/products/{id})
+
+`name`과 `category`는 **필수 필드**입니다. 기존 예시에 누락되어 있어 수정했습니다.
+
+**변경 전 (오류 발생)**
+```json
+{
+  "price": 450000,
+  "description": "가격 인상된 선글라스"
+}
+```
+
+**변경 후 (정상 동작)**
+```json
+{
+  "name": "GENTLE MONSTER 01 (Updated)",
+  "price": 320000,
+  "category": "sunglasses",
+  "description": "업데이트된 선글라스",
+  "stock": 15,
+  "inStock": true,
+  "colors": [
+    { "name": "Black", "available": true },
+    { "name": "Silver", "available": true }
+  ],
+  "specifications": {
+    "frameWidth": "140mm",
+    "lensHeight": "50mm",
+    "lensWidth": "52mm",
+    "bridgeWidth": "21mm",
+    "templeLength": "145mm"
+  }
+}
+```
+
+> `name`, `category`는 필수입니다. `colors`, `specifications`, `images`는 선택입니다.
+
+---
+
+### 2. 주문 생성 (POST /orders)
+
+요청 형식이 실제 API와 완전히 달랐습니다. 수정했습니다.
+
+**변경 전 (500 오류 발생)**
+```json
+{
+  "items": [
+    { "cartItemId": 1, "quantity": 1 }
+  ],
+  "shippingAddress": "서울시 강남구 테헤란로 123",
+  "pointsToUse": 50000
+}
+```
+
+**변경 후 (정상 동작)**
+```json
+{
+  "items": [
+    {
+      "productId": 1,
+      "quantity": 1,
+      "color": "Black",
+      "price": 290000
+    }
+  ],
+  "shippingAddress": {
+    "recipientName": "홍길동",
+    "phone": "010-1234-5678",
+    "address": "서울시 강남구 테헤란로 123",
+    "addressDetail": "4층 401호",
+    "zipCode": "12345"
+  },
+  "paymentMethod": "points",
+  "pointsToUse": 290000
+}
+```
+
+**주요 변경점:**
+- `items[].cartItemId` → `items[].productId` + `color` + `price`
+- `shippingAddress` 문자열 → 객체 (`recipientName`, `phone`, `address`, `addressDetail`, `zipCode`)
+- `paymentMethod: "points"` 필드 추가
+
+---
+
+## 테스트 결과
+
+| API | 결과 |
+|-----|------|
+| PUT /admin/products/2 (수정된 예시) | **200 성공** |
+| POST /orders (수정된 예시) | **201 성공** |
+
+API 문서 페이지: https://www.fullstackfamily.com/gentlelion/api-docs


### PR DESCRIPTION
## 요약

3조 피드백을 반영하여 API 문서의 Try it 예시를 수정했습니다.

## 변경 내용

### 상품 수정 (PUT /admin/products/{id})
- `name`, `category` 필수 필드가 누락되어 있어 추가
- `colors`, `specifications` 예시도 포함

### 주문 생성 (POST /orders)
- `cartItemId` → `productId` + `color` + `price`
- `shippingAddress` 문자열 → 객체 (recipientName, phone, address, addressDetail, zipCode)
- `paymentMethod: "points"` 필드 추가

## 테스트 결과

두 API 모두 수정된 예시로 **정상 동작** 확인.

상세: `docs/api-fix-20260406.md`