### PR TITLE
docs: Cart/Wishlist 응답 images 배열 변경 안내 (2026-04-11)

### DIFF
--- a/docs/api-fix-20260411.md
+++ b/docs/api-fix-20260411.md
@@ -1,0 +1,269 @@
+# GentleLion API 수정 안내 (2026-04-11)
+
+> 학생 피드백 반영: 장바구니/위시리스트 응답 필드를 `images` 배열로 통일
+
+---
+
+## 요청 사항 정리
+
+학생 요청 원문:
+
+> 수정 요청 API 항목
+> - Product(상품) - GET 메서드
+> - 장바구니 조회 - GET 메서드
+> - 위시리스트 조회 - GET 메서드
+>
+> 썸네일이 아닌 images 리소스로 반영 요청드립니다.
+> 현재 데이터는 thumbnail 리소스로 오고 있습니다.
+> 썸네일 리소스는 따로 사용하지 않아서 이를 상품을 등록할 때 사용되는 Images 리소스로 수정 요청드립니다.
+
+## 사실 확인
+
+요청 검증을 위해 실제 API를 호출해 본 결과:
+
+| API | 학생이 본 것 | 실제 응답 (변경 전) |
+|-----|------------|-------------------|
+| `GET /products` | `thumbnail` | **이미 `images` 배열** ✓ |
+| `GET /cart` | `thumbnail` | `image` (단수, 첫 이미지 1장) |
+| `GET /wishlist` | `thumbnail` | `image` (단수, 첫 이미지 1장) |
+
+`thumbnail`이라는 필드는 실제 API 응답에는 존재하지 않았습니다. 다만 **API 문서(`/gentlelion/api-docs` 페이지)에 `thumbnail`로 잘못 표기**되어 있어서 학생이 그렇게 인지한 것이 원인이었습니다.
+
+요청의 핵심 의도(상품 등록의 `images` 필드와 응답 일관성을 맞춰 달라)는 타당하므로 다음과 같이 처리했습니다.
+
+---
+
+## 변경 내용
+
+### 1. 백엔드 응답 변경 (Cart, Wishlist)
+
+| Endpoint | Before | After |
+|----------|--------|-------|
+| `GET /api/gentlelion/v1/cart` | `image: string` (1장) | `images: string[]` (전체 배열) |
+| `GET /api/gentlelion/v1/wishlist` | `image: string` (1장) | `images: string[]` (전체 배열) |
+
+`GET /api/gentlelion/v1/products`는 이미 `images` 배열로 응답하고 있어서 변경 없음.
+
+### 2. API 문서 수정
+
+`https://www.fullstackfamily.com/gentlelion/api-docs` 에 표기된 `thumbnail`을 모두 실제 응답과 일치하도록 수정했습니다.
+
+### 3. ⚠️ Breaking Change
+
+기존에 `image` 필드를 사용하던 코드는 수정이 필요합니다.
+
+```js
+// Before
+cartItem.image          // string
+
+// After
+cartItem.images         // string[]
+cartItem.images[0]      // 첫 번째 이미지
+```
+
+---
+
+## 새 응답 스펙
+
+### GET /api/gentlelion/v1/cart
+
+```json
+{
+  "success": true,
+  "data": {
+    "items": [
+      {
+        "cartItemId": 1,
+        "productId": 1,
+        "name": "GENTLE MONSTER 01",
+        "price": 290000,
+        "prevPrice": 290000,
+        "quantity": 2,
+        "images": [
+          "https://storage.fullstackfamily.com/content/gentlelion/images/abc-1.jpg",
+          "https://storage.fullstackfamily.com/content/gentlelion/images/abc-2.jpg"
+        ],
+        "color": "Black"
+      }
+    ],
+    "totalPrice": 580000,
+    "itemCount": 1
+  }
+}
+```
+
+### GET /api/gentlelion/v1/wishlist
+
+```json
+{
+  "success": true,
+  "data": {
+    "items": [
+      {
+        "wishlistItemId": 1,
+        "productId": 1,
+        "name": "GENTLE MONSTER 01",
+        "price": 290000,
+        "images": [
+          "https://storage.fullstackfamily.com/content/gentlelion/images/abc-1.jpg",
+          "https://storage.fullstackfamily.com/content/gentlelion/images/abc-2.jpg"
+        ],
+        "color": "Black",
+        "inStock": true
+      }
+    ],
+    "itemCount": 1
+  }
+}
+```
+
+### GET /api/gentlelion/v1/products (변경 없음)
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": 65,
+      "name": "New Sunglasses",
+      "price": 420000,
+      "category": "sunglasses",
+      "images": [
+        "https://storage.fullstackfamily.com/content/gentlelion/images/abc.jpg"
+      ],
+      "colors": [...],
+      "specifications": {...},
+      "stock": 0,
+      "inStock": false
+    }
+  ]
+}
+```
+
+---
+
+## 프론트엔드 코드 수정 가이드
+
+### Cart 리스트 렌더링
+
+`src/components/cart/cartCard.js`:
+
+```diff
+  for (const product of data.data.items) {
+      ...
+      const img = card.querySelector(".cart-product-image");
+      if (img) {
+-         img.src = product.imageUrl ?? '...fallback url...';
++         img.src = product.images?.[0] ?? '...fallback url...';
+          img.alt = product.name ?? '';
+      }
+      ...
+  }
+```
+
+> 참고: 기존 코드는 `product.imageUrl`을 참조하고 있었는데, 이 필드는 어떤 시점의 API에도 존재한 적이 없습니다. 따라서 항상 fallback URL이 사용되고 있었습니다. 이번 변경을 계기로 `product.images?.[0]`로 교정해 주세요.
+
+### Wishlist 리스트 렌더링
+
+위시리스트도 동일 패턴으로 `images?.[0]`을 사용하면 됩니다.
+
+```js
+const imageUrl = item.images?.[0] ?? '...fallback...';
+```
+
+### 여러 장 표시 (선택)
+
+이제 모든 이미지를 받을 수 있으므로, 슬라이더/캐러셀로 여러 장을 표시하고 싶다면 `images` 배열 전체를 사용할 수 있습니다.
+
+```js
+item.images.forEach((url, idx) => {
+  const slide = document.createElement('img');
+  slide.src = url;
+  slide.alt = `${item.name} ${idx + 1}`;
+  carousel.appendChild(slide);
+});
+```
+
+---
+
+## 호환성 정책
+
+- 이번 변경은 **Breaking Change** 입니다. 기존 `image` 필드는 응답에서 제거되었습니다.
+- 학생 프로젝트의 `cartCard.js` 등 cart/wishlist 렌더링 코드를 함께 업데이트해 주세요.
+
+---
+
+## 비대상
+
+- **주문(Order) API**는 이번 변경 범위에 포함되지 않습니다. 주문은 구매 시점의 이미지 스냅샷을 단일 필드로 저장하므로 `image: string`을 그대로 유지합니다.
+
+---
+
+## 배포 후 라이브 검증
+
+배포 직후 실제 운영 API를 호출하여 변경이 적용된 것을 확인했습니다.
+
+```bash
+# 1) 회원가입 + 로그인으로 토큰 발급
+curl -X POST https://api.fullstackfamily.com/api/gentlelion/v1/auth/signup \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@example.com","password":"TestPass123!","firstName":"Tes","lastName":"Ter"}'
+
+LOGIN=$(curl -s -X POST https://api.fullstackfamily.com/api/gentlelion/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@example.com","password":"TestPass123!"}')
+TOKEN=$(echo "$LOGIN" | jq -r '.token')
+
+# 2) 장바구니에 상품 추가 (product id 10은 이미지 2장 보유)
+curl -X POST https://api.fullstackfamily.com/api/gentlelion/v1/cart \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"productId":10,"quantity":1,"color":"Black"}'
+
+# 3) 장바구니 조회
+curl https://api.fullstackfamily.com/api/gentlelion/v1/cart \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**실제 응답 (2026-04-11 배포 후):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "items": [
+      {
+        "cartItemId": 26,
+        "productId": 10,
+        "name": "GENTLE MONSTER 10",
+        "price": 350000,
+        "prevPrice": 350000,
+        "quantity": 1,
+        "images": [
+          "https://placehold.co/400x300?text=GM-10-1",
+          "https://placehold.co/400x300?text=GM-10-2"
+        ],
+        "color": "Black"
+      }
+    ],
+    "totalPrice": 350000,
+    "itemCount": 1
+  }
+}
+```
+
+위시리스트도 동일하게 `images` 배열로 응답함을 확인했습니다 (2장 모두 정상 반환).
+
+---
+
+## 적용 일시
+
+- 백엔드 PR 머지: 2026-04-11
+- 백엔드 배포 완료: 2026-04-11 (Deploy Backend to OCI VM, success)
+- 프론트엔드 문서 배포 완료: 2026-04-11 (Deploy Frontend to OCI VM, success)
+- 라이브 API 검증 완료: 2026-04-11
+
+## 관련 PR
+
+- 백엔드: `urstory/fullstackfamily-backend#1` (merged)
+- 프론트엔드 문서: `urstory/fullstackfamily-frontend#5` (merged)


### PR DESCRIPTION
## 배경

학생 피드백을 받아 GentleLion 백엔드 API의 Cart/Wishlist 조회 응답 형식을 변경했습니다. 이 PR은 변경 내용을 학생들에게 안내하기 위한 문서입니다.

## 학생 요청 원문

> 수정 요청 API 항목
> - Product(상품) - GET 메서드
> - 장바구니 조회 - GET 메서드
> - 위시리스트 조회 - GET 메서드
>
> 썸네일이 아닌 images 리소스로 반영 요청드립니다.
> 현재 데이터는 thumbnail 리소스로 오고 있습니다.

## 사실 확인 결과

| API | 학생이 본 것 | 변경 전 실제 응답 | 변경 후 |
|-----|-------------|-----------------|---------|
| `GET /products` | `thumbnail` | 이미 `images` 배열이었음 ✓ | 변경 없음 |
| `GET /cart` | `thumbnail` | `image` (단수, 첫 1장만) | **`images` 배열** |
| `GET /wishlist` | `thumbnail` | `image` (단수, 첫 1장만) | **`images` 배열** |

학생이 본 `thumbnail`은 실제 API가 아닌 **API 문서(api-docs 페이지)의 잘못된 표기**였습니다. 문서도 함께 수정했습니다.

## 변경 내역

### 백엔드 (fullstackfamily-backend)

- `GlCartItemResponse.image: String` → `images: List<String>`
- `GlWishlistItemResponse.image: String` → `images: List<String>`
- 통합 테스트 갱신
- PR: `urstory/fullstackfamily-backend#1` (merged & deployed)

### API 문서 (fullstackfamily-frontend)

- `https://www.fullstackfamily.com/gentlelion/api-docs` 의 응답 예시 정정
- 모든 `thumbnail` → 실제 응답과 일치하도록 수정
- PR: `urstory/fullstackfamily-frontend#5` (merged & deployed)

## ⚠️ 학생들이 해야 할 일

기존 코드에서 `cartItem.image`를 사용하고 있다면 `cartItem.images[0]`로 변경해야 합니다.

```diff
- img.src = product.imageUrl ?? 'fallback...';
+ img.src = product.images?.[0] ?? 'fallback...';
```

자세한 내용은 `docs/api-fix-20260411.md` 의 "프론트엔드 코드 수정 가이드" 섹션을 참고하세요.

## 라이브 API 검증 완료

배포 직후 운영 API를 실제로 호출하여 `images` 배열로 응답하는 것을 확인했습니다. 검증 결과는 문서에 포함되어 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)