### PR TITLE
docs: 2026-04-14 코드 리뷰 & 해결 가이드

### DIFF
--- a/docs/2026041409_리뷰.md
+++ b/docs/2026041409_리뷰.md
@@ -1,0 +1,419 @@
+# 코드 리뷰 (2026-04-14)
+
+> 대상: 최근 develop 머지 범위(`593a51e..b3e699c`) — 회원가입/주소 검색, 프로필 편집 유효성 검사, 이미지 캐러셀/색상칩 컴포넌트 분리, 상품 상세 페이지 등
+> 이전 리뷰: [20260412_리뷰.md](./20260412_리뷰.md)
+> 리뷰 관점: **응집도(cohesion)는 높이고, 결합도(coupling)는 낮춘다.** 그리고 스타일은 **TailwindCSS 우선**, CSS는 꼭 필요할 때만 최소한으로 씁니다.
+
+---
+
+## 0. 이번 리뷰 범위
+
+이번 리뷰는 이전 리뷰(2026-04-12) 이후 머지된 커밋들을 대상으로 합니다.
+
+**주요 변경 파일**
+
+- `src/components/carousel/imageCarousel.js` — 이미지 캐러셀 컴포넌트 분리 (신규)
+- `src/data/colorChips.js`, `src/data/colors.js` — 색상 칩 데이터/렌더러 분리 (신규)
+- `src/components/login/register.html` — 회원가입 폼
+- `src/components/login/handlerRegister.js` — 회원가입 폼 핸들러
+- `src/components/login/checkPassword.js`, `checkKoreanName.js`, `checkRequired.js`, `formatPhoneNumber.js` — 유효성 검사 모듈 (신규)
+- `src/components/login/addressSearch.js` — 카카오 우편번호 API 연동 (신규)
+- `src/components/login/privacy.html`, `terms.html` — 약관/개인정보 페이지 (신규)
+- `src/components/profile/profile.html`, `editProfile.js`, `handlerProfile.js`, `editProfileSaveButton.js`
+- `src/components/API/profile/putProfileApi.js` — 부분 업데이트 구조로 변경
+- `src/pages/product-detail.html` — 상품 상세 페이지 전면 개편
+- `src/pages/collection.html` — 컬렉션 페이지에 상품 목록 통합
+- `src/components/item/item.js` — `createItem` 함수로 분리
+- `src/components/productCard/productCard.js`, `productCard.html` — 이미지 바인딩 추가
+
+**이전 리뷰 잘 해결된 것 👏**
+- ✅ `register.html`에서 체크박스 `id`가 모두 같던 문제가 `agreeAll`, `agreeTerms`, `agreeAge`, `agreeNewsletter`, `agreePrivacy`로 각각 구분됨
+- ✅ `postRegisterApi`, `putProfileApi`가 매개변수 객체 분해 방식(`{ firstName, lastName, phone }`)으로 개선됨
+- ✅ `handlerRegister.js`에 비밀번호 일치 검사 / 한글 이름 검사 / 필수 약관 동의 검사가 추가됨
+- ✅ 카카오 우편번호 API로 주소 검색을 실제로 구현한 것은 아주 잘했어요
+- ✅ `imageCarousel`, `colorChips`를 별도 파일로 분리한 시도 자체가 좋은 방향이에요
+
+**이전 리뷰에서 아직 해결되지 않은 것**
+- ⚠ 모바일 메뉴가 여전히 페이지마다 복붙됨 (`register.html`, `profile.html`, `collection.html`)
+- ⚠ `productCard.js`의 `console.log`가 다시 추가되었습니다 (8번 줄)
+- ⚠ `handlerRegister.js`에서 `postRegisterApi(email, pw, fn, ln, phone, address, addressDetail)` — 여전히 7개 위치 인자로 호출
+- 이전 리뷰 [20260412_리뷰.md](./20260412_리뷰.md)를 꼭 함께 봐주세요.
+
+---
+
+## 1. 리뷰 요약
+
+| 구분 | 발견 건수 |
+|------|----------|
+| 심각 (반드시 수정) | 4건 |
+| 개선 권장 | 6건 |
+| 참고 사항 | 3건 |
+
+---
+
+## 2. 잘한 점
+
+리뷰는 문제점 지적이 목적이 아니라 **다음 번에 더 잘하기 위한 힌트**를 주는 것이 목적이에요. 이번 변경에서 잘한 점부터 충분히 칭찬할게요.
+
+### 2-1. 기능을 파일 단위로 잘게 나눈 것 — 응집도의 시작
+- `checkPassword.js`, `checkKoreanName.js`, `checkRequired.js`, `formatPhoneNumber.js` 처럼 **하나의 역할만 하는 작은 함수**로 파일을 분리한 건 정말 잘했어요.
+- 이걸 **"한 파일 = 한 가지 일(Single Responsibility)"** 이라고 부르는데, 초보 단계에서 이 습관을 들이면 나중에 협업할 때 엄청난 차이가 납니다.
+
+### 2-2. 카카오 우편번호 API 연동
+- `addressSearch.js`에서 외부 스크립트를 `document.createElement("script")`로 직접 로드하고, `bindAddressSearch()`로 재사용 가능하게 만든 패턴이 아주 좋아요.
+- 하나의 함수로 `register.html`과 `profile.html` 두 곳을 동시에 지원하는 구조 — 이게 바로 "결합도를 낮춘다"의 모범 예시입니다.
+
+### 2-3. API 함수의 객체 분해 매개변수
+- `putProfileApi({ firstName, lastName, phone })` 처럼 객체로 받는 방식으로 개선된 것 👍
+- 이전 리뷰에서 지적한 "매개변수 순서 바뀌면 큰일" 문제를 훌륭하게 해결했어요.
+
+### 2-4. `item.js`에서 캐러셀을 재사용
+- `createItem()` 안에서 `createImageCarousel(images, { alt })`를 호출해서 한 곳에서 정의한 캐러셀을 그대로 쓰는 구조 — 이게 컴포넌트 분리의 진짜 이점이에요.
+
+### 2-5. 프로필 편집 + 유효성 검사 연결
+- `handlerProfile.js`에서 `editFn`, `editLn` 입력 이벤트에 한글 검사를 붙이고, `editNameError`라는 **전용 에러 요소를 별도로 두고** `classList.toggle("hidden", isValid)`로 숨김/표시를 제어한 방식이 깔끔합니다.
+
+---
+
+## 3. 개선하면 좋을 점
+
+### 3-1. `product-detail.html`에 약 150줄짜리 inline `<style>` 블록이 있어요 (중요도: 높음)
+
+**파일**: `src/pages/product-detail.html` 15~168줄
+
+```html
+<style>
+  .acc-content { max-height: 0; overflow: hidden; transition: max-height 0.35s ease; }
+  .acc-content.open { max-height: 600px; }
+  .pdp-img-container { position: relative; width: 100%; padding-top: 100%; ... }
+  .mobile-slider-wrap { position: relative; width: 100%; aspect-ratio: 344 / 478; ... }
+  .mobile-slider-track { ... }
+  .mobile-slide { ... }
+  .slider-dots { ... }
+  .slider-dot { ... }
+  @media (min-width: 769px) { ... }
+  @media (max-width: 768px) { ... }
+  .similar-img-wrap { ... }
+  /* ... 약 150줄 ... */
+</style>
+```
+
+**왜 개선하면 좋을까요?**
+
+이 프로젝트는 **TailwindCSS**를 사용하는 프로젝트입니다. 그런데 상품 상세 페이지의 HTML 파일에만 150줄짜리 CSS가 따로 적혀 있으면 이런 문제가 생겨요.
+
+1. **같은 스타일을 두 가지 방식으로 쓰게 됩니다.** 어떤 곳은 `class="flex items-center"`, 어떤 곳은 `.mobile-slider-wrap { display: flex; }` — 팀원이 나중에 "이거 어디서 스타일이 오는 거지?" 하고 헷갈리게 됩니다.
+2. **반응형 `@media` 쿼리를 직접 작성하고 있습니다.** 그런데 Tailwind에는 `md:flex`, `max-md:flex-col` 같은 반응형 유틸리티가 이미 있어요. 같은 일을 두 번 하는 셈이에요.
+3. **`!important`를 남발하게 됩니다.** 17번 줄의 `height: 100% !important;`처럼요. `!important`가 많아지면 나중에 스타일 싸움이 나서 디버깅이 매우 어려워집니다.
+
+> 규칙은 간단합니다: **Tailwind로 안 되는 경우만 CSS를 쓰되, 그마저도 `src/components/style.css` 같은 공용 파일로 보내세요.** HTML 안에 `<style>`은 넣지 않는 것이 원칙이에요.
+
+---
+
+### 3-2. `register.html`의 `<label for="...">`가 존재하지 않는 id를 가리켜요 (중요도: 높음)
+
+**파일**: `src/components/login/register.html` 233~371줄
+
+```html
+<input type="checkbox" id="agreeAll" ... />
+<label for="default-checkbox" class="select-none ms-2 text-[13px]">모두 동의하기</label>
+
+<input type="checkbox" id="agreeTerms" ... />
+<label for="checked-checkbox" class="select-none ...">이용약관에 동의합니다.</label>
+
+<input type="checkbox" id="agreeAge" ... />
+<label for="checked-checkbox" class="select-none ...">만 14세 이상입니다.</label>
+```
+
+**왜 개선하면 좋을까요?**
+
+체크박스의 `id`는 이제 `agreeAll`, `agreeTerms`, `agreeAge`처럼 **잘 나누어졌는데**, 막상 `<label for="...">` 쪽은 여전히 예전의 `default-checkbox`, `checked-checkbox`를 가리키고 있어요. 이 id는 페이지 어디에도 존재하지 않아요.
+
+이렇게 되면:
+- "모두 동의하기" **라벨 글씨를 클릭해도 체크박스가 체크되지 않아요.** SVG가 `peer-checked`로 반응해서 시각적으로는 체크된 것처럼 보이지만, 실제로는 input의 상태가 안 바뀝니다.
+- 스크린 리더 사용자는 "이 라벨이 어떤 입력에 속하는 건지" 알 수 없어서 접근성이 크게 떨어져요.
+
+> **쉽게 말하면:** 전화번호부에 이름은 바꿨는데, 발신 기록은 옛날 번호로 돼 있는 상황이에요. 이름이 있으니 보기엔 맞는 것 같지만, 정작 전화는 다른 번호로 걸리는 거죠.
+
+---
+
+### 3-3. `imageCarousel.js`가 전부 `style.cssText`로 스타일을 줍니다 (중요도: 높음)
+
+**파일**: `src/components/carousel/imageCarousel.js` 1~40줄 등
+
+```javascript
+imageWrap.style.cssText =
+  "position:relative;width:100%;aspect-ratio:520 / 718;overflow:hidden;" +
+  "background:#F3F4F6;cursor:grab;user-select:none;-webkit-user-select:none;";
+// ...
+track.style.cssText =
+  "position:absolute;top:0;left:0;height:100%;" +
+  "display:flex;transition:transform 0.3s ease;will-change:transform;";
+// ...
+slide.style.cssText = `flex:0 0 ${100 / images.length}%;max-width:${100 / images.length}%;height:100%;overflow:hidden;`;
+```
+
+**왜 개선하면 좋을까요?**
+
+캐러셀을 별도 컴포넌트로 분리한 것까지는 정말 잘했어요. 그런데 **스타일 지정을 전부 JavaScript 문자열**로 하고 있습니다. 이건 사실상 "CSS를 JS 안에 집어넣은 것"과 같아서, 프로젝트가 정한 "Tailwind 우선" 원칙에서 벗어납니다.
+
+문제점:
+1. 팀 전체 스타일 규칙(`style.css`의 `--bg` 등)을 쓸 수 없어요.
+2. 검색이 어렵습니다. "background-color가 어디서 설정됐지?" 찾으려면 JS 파일까지 열어야 해요.
+3. 디자이너가 톤&매너를 바꾸려면 JS 문자열을 뜯어야 합니다.
+
+> **단, 슬라이드 위치 이동(`translateX`) 같은 "동적으로 바뀌는 값"은 JS로 설정해야 해요.** 바뀌지 않는 **레이아웃 스타일만** 클래스로 옮기면 됩니다.
+
+---
+
+### 3-4. `productCard.js`에 `console.log`가 다시 들어있어요 (중요도: 높음)
+
+**파일**: `src/components/productCard/productCard.js` 8번 줄
+
+```javascript
+for (const product of products.data) {
+    console.log(product.images[0]);  // ← 이 줄
+```
+
+**왜 개선하면 좋을까요?**
+
+이전 리뷰(2026-04-12)에서 똑같은 지적이 있었어요. 이 `console.log`는 사용자 브라우저의 콘솔에 **상품 이미지 URL을 하나하나 찍어줍니다**. 카탈로그 페이지를 열 때마다요.
+
+디버깅이 끝났으면 반드시 삭제해야 합니다. 팁을 드리면:
+- 개발 중에만 필요한 `console.log`는 **커밋 직전에 `git diff`로 꼭 훑어보기**
+- VSCode의 Find(⌘F)로 `console.log`를 검색해서 남아있는지 확인하기
+- 이후에는 ESLint의 `no-console` 규칙을 도입하는 걸 고려해보세요.
+
+---
+
+### 3-5. `product-detail.html`에 260줄짜리 `<script>`가 박혀 있어요 (중요도: 중간)
+
+**파일**: `src/pages/product-detail.html` 317~575줄
+
+```html
+<script type="module">
+  import { collections } from "../data/collection.js";
+  import { renderColorChips } from "../data/colorChips.js";
+  // ... 260줄의 페이지 로직 ...
+  // - URL 파라미터 파싱
+  // - 상품 찾기
+  // - 모바일 슬라이더 생성
+  // - pointer 이벤트 드래그 처리
+  // - 데스크탑 썸네일 생성
+  // - 아코디언 펼침/접힘
+  // - 찜하기 버튼
+  // - 유사 상품 그리드
+</script>
+```
+
+**왜 개선하면 좋을까요?**
+
+HTML 파일은 "어떤 요소가 어디에 있는지"를 나타내는 역할이고, JavaScript는 "어떻게 동작하는지"를 담당해요. 이게 **관심사의 분리(Separation of Concerns)** 입니다.
+
+- 지금은 HTML 한 파일 안에 **둘이 섞여 있어서** 270줄짜리 페이지 로직이 뷰 파일 안에 들어 있어요.
+- 그 결과, 이미 분리해둔 `imageCarousel.js`가 있는데도 **비슷한 슬라이더 로직을 또 다시** `<script>` 안에 쓰고 있습니다(399~443줄의 pointer 이벤트 처리 부분).
+- 이걸 고치지 않으면, 슬라이더 버그가 생겼을 때 **두 곳을 모두** 고쳐야 해요.
+
+> **쉽게 말하면:** 주방과 식당 홀을 한 공간에 섞어 놓은 것과 같아요. 손님이 늘면 주방 동선과 홀 동선이 엉키죠. JS 파일을 분리하는 건 주방을 따로 내는 거예요.
+
+---
+
+### 3-6. `product-detail.html`의 슬라이더와 `imageCarousel.js`가 거의 같은 코드입니다 (중요도: 중간)
+
+**파일**: 
+- `src/pages/product-detail.html` 396~443줄
+- `src/components/carousel/imageCarousel.js` 72~121줄
+
+```javascript
+// product-detail.html 내부 (399~437줄)
+let ptrStartX = 0, ptrDown = false, ptrDragging = false;
+sliderWrap.addEventListener("pointerdown", (e) => {
+  ptrDown = true;
+  ptrDragging = false;
+  ptrStartX = e.clientX;
+  // ...
+});
+sliderWrap.addEventListener("pointermove", (e) => {
+  if (!ptrDown) return;
+  const diff = e.clientX - ptrStartX;
+  if (!ptrDragging && Math.abs(diff) > 5) ptrDragging = true;
+  // ...
+});
+```
+
+```javascript
+// imageCarousel.js 내부 (83~99줄) — 거의 같음
+function onMove(clientX) {
+  if (!isDown) return;
+  currentX = clientX;
+  const diff = currentX - startX;
+  if (!isDragging && Math.abs(diff) > 5) {
+    isDragging = true;
+    moved = true;
+  }
+  // ...
+}
+```
+
+**왜 개선하면 좋을까요?**
+
+캐러셀 컴포넌트를 만든 목적은 **같은 로직을 두 번 쓰지 않기 위해서**예요. 그런데 상품 상세 페이지는 컴포넌트를 사용하지 않고 **비슷한 코드를 처음부터 다시 작성**했어요.
+
+- `imageCarousel.js`는 `product.images`를 주면 완성된 DOM을 돌려주도록 이미 만들어져 있어요.
+- `product-detail.html`에서도 똑같은 방식(`createImageCarousel(images, { alt })`)으로 쓸 수 있습니다.
+
+이렇게 해야 나중에 "캐러셀 도트를 원형으로 바꿔주세요" 같은 요청이 왔을 때, 한 군데만 고치면 모든 곳에 반영됩니다.
+
+---
+
+### 3-7. 유효성 검사 함수들이 `style.borderColor`를 직접 조작합니다 (중요도: 중간)
+
+**파일**: 
+- `src/components/login/checkKoreanName.js`
+- `src/components/login/checkPassword.js`
+- `src/components/login/checkRequired.js`
+
+```javascript
+// checkKoreanName.js
+if (!koreanOnly.test(input.value)) {
+  input.style.borderColor = "red";
+  return false;
+}
+input.style.borderColor = "";
+
+// checkRequired.js
+agreeTerms.style.outlineColor = "red";
+agreeTerms.style.outlineStyle = "solid";
+agreeTerms.style.outlineWidth = "1px";
+```
+
+**왜 개선하면 좋을까요?**
+
+Tailwind를 쓰는 프로젝트인데 **검증 에러 표시만 인라인 스타일**로 처리되고 있어요. 이렇게 되면:
+
+1. 에러 상태의 색상을 바꾸려면 **모든 검증 파일을 뒤져서 `"red"`를 찾아야** 합니다.
+2. 프로젝트의 디자인 시스템(`--red` 변수 등)을 쓸 수 없어요.
+3. `input.style.borderColor = ""`처럼 빈 문자열로 초기화하는 건 Tailwind의 border 색상을 덮어쓰는 부작용이 있어요.
+
+Tailwind의 "상태 클래스 toggle" 패턴으로 바꾸면 훨씬 깔끔합니다:
+
+```javascript
+input.classList.toggle("border-red-500", !isValid);
+```
+
+---
+
+### 3-8. `handlerRegister.js`에서 여전히 7개의 위치 인자로 API를 호출해요 (중요도: 중간)
+
+**파일**: `src/components/login/handlerRegister.js` 55줄
+
+```javascript
+await postRegisterApi(email, pw, fn, ln, phone, address, addressDetail);
+```
+
+**왜 개선하면 좋을까요?**
+
+이전 리뷰에서 지적한 항목이에요. API 함수는 객체 분해를 쓰도록 개선 흐름이 있었는데, **호출하는 쪽**은 아직 위치 인자로 남아있어요.
+
+문제는 `pw`, `fn`, `ln` 순서가 바뀌면 에러도 안 나고 **틀린 데이터가 그대로 서버에 저장**된다는 점입니다. 모두 문자열이니까요.
+
+```javascript
+// 개선 후
+await postRegisterApi({ email, password: pw, firstName: fn, lastName: ln, phone, address, addressDetail });
+```
+
+이렇게 쓰면 순서가 뒤섞여도 이름이 맞으니까 안전해요. `postRegisterApi.js` 쪽도 함께 수정해야 합니다.
+
+---
+
+### 3-9. 모바일 메뉴가 여전히 페이지마다 복붙되어 있어요 (중요도: 중간)
+
+**파일**: 
+- `src/components/login/register.html` 14~57줄
+- `src/components/profile/profile.html` 13~56줄
+- `src/pages/collection.html` 259~300줄
+
+이전 리뷰에서도 지적한 항목입니다. `<nav>` 안에 "선글라스 / 안경 / 컬렉션 / 스토리 / 서비스" 같은 메뉴가 **완전히 같은 코드로** 3곳(혹은 더 많은 곳)에 복사되어 있어요.
+
+이건 프로젝트의 **응집도**를 떨어뜨리는 대표적 사례예요. 메뉴 하나 추가하려면 3개 파일을 동시에 수정해야 하거든요.
+
+이미 프로젝트에는 `layout.js`의 `loadHeader()`로 공통 헤더를 로드하는 패턴이 있어요. 모바일 메뉴도 같은 방식으로 `loadMobileMenu()` 같은 함수 하나로 모아야 합니다.
+
+---
+
+### 3-10. `register.html`에 "걔정" 오타가 있어요 (중요도: 낮음)
+
+**파일**: `src/components/login/register.html` 69줄
+
+```html
+<p class="text-[13px] leading-[1.6] text-[#111] mb-8">
+  아래 필드에 정보를 입력하여 걔정을 생성하고 특별한 서비스를
+  만나보세요.
+</p>
+```
+
+→ "걔정" 이 아니라 "계정"입니다. 사용자에게 직접 보이는 문구이므로 꼭 고쳐주세요.
+
+---
+
+## 4. 참고 사항
+
+### 4-1. `addressSearch.js`의 `editAdress` 오타
+
+`src/components/login/addressSearch.js` 7번 줄:
+
+```javascript
+bindAddressSearch("profileAddressSearchBtn", "editAdress", "editAdressDetail");
+```
+
+영어 단어 "address"는 d가 하나가 아니라 **2개**(ad-**d**-ress)예요. HTML의 `id`도 같은 오타(`editAdress`)라서 **지금은 동작**하지만, 나중에 누군가 맞춤법을 고치면 연쇄적으로 깨집니다. 프로필 편집 폼의 id와 함께 `editAddress`, `editAddressDetail`로 동시에 고쳐두세요.
+
+### 4-2. `data/colors.js`에 상품이 1개만 있어요
+
+`productColors` 객체에 `"0PEEZ09X6ASH7"` 하나만 정의되어 있어서, 다른 상품 상세 페이지에 들어가면 색상 칩이 전혀 안 보입니다. `colorChips.js`의 초기 `if (!colorData) return;` 덕분에 에러는 안 나지만, 사용자 입장에서는 "없는 것"처럼 보이므로 **목업 데이터 또는 API 연동 전까지 임시 플래그**를 두는 것이 좋아요.
+
+### 4-3. `product-detail.html`에 하드코딩된 상품 정보
+
+462~491줄에서 세부 정보("나일론 소재의 고글 선글라스", "렌즈 너비: 152.9 mm" 등)가 JavaScript 배열로 박혀 있어요. 상품마다 다른 값인데 모든 상품이 똑같이 이 값을 보여주게 됩니다. `currentProduct.details` 같은 필드를 데이터에 추가해서 그걸 렌더링하는 구조가 맞습니다.
+
+---
+
+## 5. 파일별 요약
+
+| 파일 | 역할 | 주요 피드백 |
+|------|------|-------------|
+| `product-detail.html` | 상품 상세 페이지 | inline `<style>` 150줄 + inline `<script>` 260줄. 분리 필요 |
+| `imageCarousel.js` | 재사용 슬라이더 | 잘 분리했지만 스타일이 전부 `style.cssText`. Tailwind로 이관 권장 |
+| `register.html` | 회원가입 폼 | `label for` 깨짐(높음), "걔정" 오타, 모바일 메뉴 복붙 |
+| `handlerRegister.js` | 회원가입 핸들러 | 유효성 검사 통합은 좋음. 7-args 호출 개선 필요 |
+| `addressSearch.js` | 카카오 우편 | 좋은 모듈화. `editAdress` 오타만 정리 |
+| `check*.js` | 유효성 검사 | 역할 분리 훌륭. `style.borderColor` → Tailwind 클래스로 |
+| `profile.html` + `editProfile.js` | 프로필 편집 | 편집 버튼/저장/취소 흐름 깔끔. 모바일 메뉴 복붙만 이슈 |
+| `colorChips.js` / `colors.js` | 색상 칩 | 데이터/렌더링 분리 잘됨. 단 데이터가 1개뿐 |
+| `productCard.js` | 카탈로그 카드 | `console.log` 재발 |
+| `item.js` | 컬렉션 카드 | 캐러셀 재사용 👍. 인라인 스타일만 Tailwind로 |
+
+---
+
+## 6. 다음 단계 제안
+
+우선순위 순서대로 고쳐주세요.
+
+1. **`register.html` `<label for>` 수정** — 지금 라벨 클릭이 동작 안 해요. 5분이면 고칩니다.
+2. **`productCard.js`의 `console.log` 삭제** — 1분.
+3. **"걔정" 오타 수정** — 1분.
+4. **`product-detail.html`의 inline `<style>`을 Tailwind 클래스로 이관** — 가장 큰 작업. `acc-content`의 펼침/접힘은 예외적으로 `src/components/style.css`로 옮기는 것을 고려하세요 (max-height 애니메이션은 Tailwind로만은 까다로워요).
+5. **`product-detail.html`의 `<script>`를 `src/pages/productDetail.js`로 분리 + `createImageCarousel` 재사용** — 응집도/결합도 모두 개선되는 핵심 작업.
+6. **유효성 검사 함수의 `style.borderColor` → `classList.toggle`** — Tailwind 원칙 맞추기.
+7. **`handlerRegister.js`의 7-args 호출을 객체 인자로 변경.**
+8. **모바일 메뉴 공통화** — 이건 팀원들과 시간을 잡고 `loadMobileMenu()` 패턴으로 정리.
+
+---
+
+## 7. 마무리
+
+이번 변경에는 "기능을 작게 쪼개기"라는 좋은 리팩터링 흐름이 보입니다. `checkPassword`, `checkKoreanName`, `addressSearch`, `colorChips`, `imageCarousel`을 전부 별도 파일로 뽑아낸 것은 **응집도를 높이기 위한 첫 번째 단계**예요. 아주 잘했어요.
+
+남은 과제는 "분리한 것을 **실제로 사용**하기"입니다. 캐러셀을 분리했는데 상품 상세에서는 다시 새로 썼고, 검사 함수를 분리했는데 에러 표시는 인라인 스타일로 들어갔어요. **"분리 + 재사용 + 일관된 스타일"** 이 세 가지가 합쳐져야 리팩터링이 완성됩니다.
+
+다음 스프린트에서는 "새 기능"보다는 이번 리뷰의 3-4, 3-5, 3-6 항목을 **리팩터링 전용 PR** 하나로 묶어 해결해보세요. 그게 지금 프로젝트에 가장 큰 품질 향상이 될 거예요. 잘하고 있어요, 파이팅! 💪

--- a/docs/2026041409_리뷰_해결.md
+++ b/docs/2026041409_리뷰_해결.md
@@ -1,0 +1,685 @@
+# 리뷰 해결 가이드 (2026-04-14)
+
+> 원본 리뷰: [2026041409_리뷰.md](./2026041409_리뷰.md)
+> 대상: `593a51e..b3e699c` 머지 범위
+> 이전 해결 가이드: [20260412_리뷰_해결.md](./20260412_리뷰_해결.md)
+
+이 문서는 리뷰에서 찾은 각 항목을 **어떻게 고치는지** 단계별로 보여줍니다. 복사해서 그대로 붙여 넣어도 동작하도록 작성했어요. 위에서부터 순서대로 따라가세요.
+
+---
+
+## 3-1. `product-detail.html`의 inline `<style>` 제거 (중요도: 높음)
+
+### 문제
+
+`src/pages/product-detail.html` 15~168번째 줄에 약 150줄의 CSS가 `<style>` 태그 안에 들어 있습니다. Tailwind 프로젝트인데 같은 기능을 두 가지 방식으로 쓰고 있어요.
+
+### 해결 방법
+
+CSS를 세 가지로 분류해서 처리합니다.
+
+**A. Tailwind 유틸리티로 그대로 대체 가능한 것** — HTML에 클래스로 옮깁니다.
+**B. 애니메이션처럼 Tailwind로 까다로운 것** — `src/components/style.css`로 옮깁니다.
+**C. 완전히 중복이거나 불필요한 것** — 삭제합니다.
+
+**Step 1.** `<style>` 태그의 `.pdp-img-container`, `.similar-img-wrap` 같은 **고정 비율 컨테이너**는 Tailwind의 `aspect-*` 유틸리티로 옮깁니다.
+
+```html
+<!-- 수정 전 (product-detail.html 29~45줄) -->
+<style>
+  .pdp-img-container {
+    position: relative;
+    width: 100%;
+    padding-top: 100%;
+    overflow: hidden;
+    background: #f3f4f6;
+  }
+  .pdp-img-container img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100% !important;
+    object-fit: contain;
+    object-position: center;
+    display: block;
+  }
+</style>
+```
+
+```javascript
+// 수정 후 — <script> 안의 데스크탑 썸네일 생성 부분(445~454줄)
+images.forEach((src, i) => {
+  const wrap = document.createElement("div");
+  wrap.className = "relative w-full aspect-square overflow-hidden bg-[#f3f4f6]";
+  const img = document.createElement("img");
+  img.src = src;
+  img.alt = currentProduct.name;
+  img.loading = i === 0 ? "eager" : "lazy";
+  img.className = "absolute inset-0 w-full h-full object-contain";
+  wrap.appendChild(img);
+  desktopBox.appendChild(wrap);
+});
+```
+
+**Step 2.** 반응형 레이아웃(`@media (min-width: 769px)`, `@media (max-width: 768px)`)은 Tailwind 반응형 유틸리티로 대체합니다.
+
+```html
+<!-- 수정 전 (103~150줄) -->
+<style>
+  @media (min-width: 769px) {
+    .product-top { display: flex; flex-direction: row; }
+    .product-thumbnail { flex: 1; min-width: 0; }
+    .product-info { flex-shrink: 0; width: 423px; }
+    .product-info-box { position: sticky; top: 0; padding: 60px 60px 0 36px; width: 327px; }
+  }
+  @media (max-width: 768px) {
+    .product-top { flex-direction: column !important; }
+    .product-thumbnail, .product-info { width: 100% !important; }
+    .product-info-box { position: static !important; padding: 0 !important; width: 100% !important; }
+  }
+</style>
+
+<div class="product-top flex">
+  <div class="product-thumbnail">...</div>
+  <div class="product-info">
+    <div class="product-info-box">...</div>
+  </div>
+</div>
+```
+
+```html
+<!-- 수정 후 -->
+<div class="flex flex-col md:flex-row">
+  <div class="w-full md:flex-1 md:min-w-0">...</div>
+  <div class="w-full md:w-[423px] md:flex-shrink-0">
+    <div class="md:sticky md:top-0 md:pt-[60px] md:pl-[36px] md:pr-[60px] md:w-[327px]">
+      ...
+    </div>
+  </div>
+</div>
+```
+
+**Step 3.** 아코디언 애니메이션(`.acc-content { max-height }`)은 Tailwind만으론 까다로우니 **공용 CSS 파일**로 옮깁니다.
+
+```css
+/* src/components/style.css 맨 아래에 추가 */
+.acc-content {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.35s ease;
+}
+.acc-content.open {
+  max-height: 600px;
+}
+```
+
+그리고 `product-detail.html`의 `<style>` 블록은 **통째로 삭제**하세요. 삭제 후에는 `import "../components/style.css"`가 이미 `<head>`에 걸려 있으니 추가 작업이 필요 없습니다.
+
+> **쉽게 말하면:** 같은 집인데 "거실은 Tailwind 말", "상품상세 페이지만 CSS 말"을 쓰는 상황이에요. 집안 언어는 Tailwind로 통일하되, 특수한 애니메이션만 한쪽 구석(`style.css`)에 모아두면 됩니다.
+
+---
+
+## 3-2. `register.html`의 `<label for>` 연결 수정 (중요도: 높음)
+
+### 문제
+
+`src/components/login/register.html` 233~371줄. 체크박스 id는 `agreeAll`, `agreeTerms`, `agreeAge`, `agreeNewsletter`, `agreePrivacy`로 나누어졌는데, `<label for="...">`는 여전히 `default-checkbox`, `checked-checkbox`를 가리켜요. 라벨 클릭해도 체크박스가 안 바뀝니다.
+
+### 해결 방법
+
+각 라벨의 `for` 속성을 자기 짝 체크박스의 id로 고치면 됩니다.
+
+**Step 1.** "모두 동의하기" 라벨.
+
+```html
+<!-- 수정 전 (233줄) -->
+<label for="default-checkbox" class="select-none ms-2 text-[13px]">모두 동의하기</label>
+
+<!-- 수정 후 -->
+<label for="agreeAll" class="select-none ms-2 text-[13px]">모두 동의하기</label>
+```
+
+**Step 2.** "이용약관에 동의합니다" 라벨.
+
+```html
+<!-- 수정 전 (265줄) -->
+<label for="checked-checkbox" class="select-none ms-2 text-[13px]"
+  >젠틀몬스터의
+  <a href="./terms.html" target="_blank" class="underline">이용약관</a>에 동의합니다.(필수)</label>
+
+<!-- 수정 후 -->
+<label for="agreeTerms" class="select-none ms-2 text-[13px]"
+  >젠틀몬스터의
+  <a href="./terms.html" target="_blank" class="underline">이용약관</a>에 동의합니다.(필수)</label>
+```
+
+**Step 3.** "만 14세 이상입니다" 라벨(300줄) → `for="agreeAge"`.
+
+```html
+<label for="agreeAge" class="select-none ms-2 text-[13px]">만 14세 이상입니다.(필수)</label>
+```
+
+**Step 4.** "뉴스레터를 받고 싶습니다" 라벨(332줄) → `for="agreeNewsletter"`.
+
+```html
+<label for="agreeNewsletter" class="select-none ms-2 text-[13px]">젠틀몬스터 뉴스레터를 받고 싶습니다.(선택)</label>
+```
+
+**Step 5.** "개인정보 수집 및 이용에 동의" 라벨(366줄) → `for="agreePrivacy"`.
+
+```html
+<label for="agreePrivacy" class="select-none ms-2 text-[13px]"
+  >젠틀몬스터 뉴스레터 수신을 위한
+  <a href="./privacy.html" target="_blank" class="underline">개인정보 수집 및 이용</a>에 동의합니다.(선택)</label>
+```
+
+> **쉽게 말하면:** 라벨의 `for`는 "이 라벨은 저 체크박스의 이름표예요"라고 브라우저에 알려주는 포인터입니다. 포인터가 엉뚱한 곳을 가리키면 라벨 클릭이 작동하지 않고, 스크린 리더도 연결을 찾지 못합니다.
+
+---
+
+## 3-3. `imageCarousel.js`의 스타일을 클래스로 (중요도: 높음)
+
+### 문제
+
+`src/components/carousel/imageCarousel.js` 전체. 정적 스타일이 전부 `style.cssText` 문자열로 지정되어 있어 Tailwind 시스템과 어긋납니다.
+
+### 해결 방법
+
+**정적 레이아웃** → Tailwind 클래스 / **동적 값(위치 이동 등)** → JS `style`로 남깁니다.
+
+**Step 1.** 최상위 `imageWrap`의 스타일을 className으로 옮깁니다.
+
+```javascript
+// 수정 전 (4~8줄)
+const imageWrap = document.createElement("div");
+imageWrap.style.cssText =
+  "position:relative;width:100%;aspect-ratio:520 / 718;overflow:hidden;" +
+  "background:#F3F4F6;cursor:grab;user-select:none;-webkit-user-select:none;";
+imageWrap.style.touchAction = "pan-y";
+
+// 수정 후
+const imageWrap = document.createElement("div");
+imageWrap.className =
+  "relative w-full aspect-[520/718] overflow-hidden bg-[#F3F4F6] " +
+  "cursor-grab select-none touch-pan-y";
+```
+
+**Step 2.** `track`의 정적 스타일도 같은 방식으로. 단 `transform`은 동적이므로 JS에 남깁니다.
+
+```javascript
+// 수정 전 (18~23줄)
+const track = document.createElement("div");
+track.style.cssText =
+  "position:absolute;top:0;left:0;height:100%;" +
+  "display:flex;transition:transform 0.3s ease;will-change:transform;";
+track.style.width = `${images.length * 100}%`;
+track.style.touchAction = "pan-y";
+
+// 수정 후
+const track = document.createElement("div");
+track.className =
+  "absolute inset-y-0 left-0 flex transition-transform duration-300 ease will-change-transform touch-pan-y";
+track.style.width = `${images.length * 100}%`;   // 동적이므로 style 유지
+```
+
+**Step 3.** 각 `slide`도 동일하게 정적 부분만 분리합니다.
+
+```javascript
+// 수정 전 (26~27줄)
+const slide = document.createElement("div");
+slide.style.cssText = `flex:0 0 ${100 / images.length}%;max-width:${100 / images.length}%;height:100%;overflow:hidden;`;
+
+// 수정 후
+const slide = document.createElement("div");
+slide.className = "h-full overflow-hidden flex-shrink-0";
+slide.style.flexBasis = `${100 / images.length}%`;  // 동적
+slide.style.maxWidth = `${100 / images.length}%`;   // 동적
+```
+
+**Step 4.** `img`, `pagination`, `bullet` 요소도 같은 원칙으로 변환합니다. 여기서는 예시만 보여줄게요.
+
+```javascript
+// bullet
+const bullet = document.createElement("span");
+bullet.className =
+  "inline-block w-2 h-px cursor-pointer transition-colors duration-200 pointer-events-auto";
+bullet.style.backgroundColor =
+  i === 0 ? "rgb(28,26,26)" : "rgba(28,26,26,0.25)";  // 동적 상태
+```
+
+> **쉽게 말하면:** "집 구조(벽, 방)"는 고정이니 Tailwind로 찍고, "가구가 어디에 있느냐(움직이는 위치)"는 JS로 옮깁니다. 움직이지 않는 것까지 JS로 찍으면 나중에 벽지를 바꿀 때 JS 파일을 뒤져야 해요.
+
+---
+
+## 3-4. `productCard.js`의 `console.log` 삭제 (중요도: 높음)
+
+### 문제
+
+`src/components/productCard/productCard.js` 8번 줄.
+
+### 해결 방법
+
+**Step 1.** 해당 한 줄만 지우면 됩니다.
+
+```javascript
+// 수정 전 (7~9줄)
+for (const product of products.data) {
+    console.log(product.images[0]);
+
+    const parser = new DOMParser();
+
+// 수정 후
+for (const product of products.data) {
+    const parser = new DOMParser();
+```
+
+**Step 2.** 다른 파일에도 남은 `console.log`가 있는지 전체 검색으로 확인하세요.
+
+```bash
+# 프로젝트 루트에서
+grep -rn "console.log" src/ admin/
+```
+
+> **쉽게 말하면:** 시험 답안지에 낙서해 놓고 그대로 제출한 것과 같아요. 커밋 직전에 `git diff`를 한 번 훑어보는 습관을 들이면 이런 일을 막을 수 있습니다.
+
+---
+
+## 3-5. `product-detail.html`의 `<script>`를 별도 JS 파일로 분리 (중요도: 중간)
+
+### 문제
+
+`src/pages/product-detail.html` 317~575번째 줄. 260줄짜리 페이지 로직이 HTML 파일에 박혀 있어서 재사용이 안 되고 `imageCarousel`을 재활용하지도 못합니다.
+
+### 해결 방법
+
+**Step 1.** 새 파일 `src/pages/productDetail.js`를 만들고 로직을 옮깁니다.
+
+```javascript
+// src/pages/productDetail.js (신규)
+import { collections } from "../data/collection.js";
+import { renderColorChips } from "../data/colorChips.js";
+import { createImageCarousel } from "../components/carousel/imageCarousel.js";
+
+function findProduct() {
+  const params = new URLSearchParams(window.location.search);
+  const collectionSlug = params.get("collectionSlug");
+  const productId = params.get("productId");
+  const collection = collections.find((c) => c.slug === collectionSlug);
+  const product = collection?.products?.find(
+    (p) => String(p.id) === String(productId),
+  );
+  return { collection, product, collectionSlug };
+}
+
+function renderProduct(product) {
+  document.getElementById("product-name").textContent = product.name;
+  const priceText = product.status
+    ? `${product.price} - ${product.status}`
+    : product.price || "";
+  document.getElementById("product-price").textContent = priceText;
+
+  // 이미지 → 분리된 캐러셀 재사용
+  const images =
+    product.images?.length > 0
+      ? product.images
+      : product.image
+        ? [product.image]
+        : [];
+  const carousel = createImageCarousel(images, { alt: product.name });
+  document.getElementById("product-thumbnail").replaceChildren(carousel);
+
+  // 색상 칩
+  renderColorChips({
+    productId: product.id,
+    chipsEl: document.getElementById("color-chips"),
+    textEl: document.getElementById("color-text"),
+  });
+}
+
+function initAccordion() {
+  document.querySelectorAll(".acc-trigger").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const id = btn.getAttribute("data-target");
+      const content = document.getElementById(id);
+      const icon = btn.querySelector(".acc-icon");
+      const isOpen = content.classList.contains("open");
+      document
+        .querySelectorAll(".acc-content")
+        .forEach((c) => c.classList.remove("open"));
+      document
+        .querySelectorAll(".acc-icon")
+        .forEach((i) => (i.textContent = "+"));
+      if (!isOpen) {
+        content.classList.add("open");
+        icon.textContent = "−";
+      }
+    });
+  });
+}
+
+function initSimilarProducts(collection, currentId, slug) {
+  const similar = (collection?.products || [])
+    .filter((p) => String(p.id) !== String(currentId))
+    .slice(0, 5);
+  if (similar.length === 0) return;
+  // ... (기존 로직을 옮겨오되 style.cssText는 className으로 교체)
+}
+
+const { collection, product, collectionSlug } = findProduct();
+if (!product) {
+  document.getElementById("product-name").textContent = "존재하지 않는 상품입니다.";
+} else {
+  renderProduct(product);
+  initAccordion();
+  initSimilarProducts(collection, product.id, collectionSlug);
+}
+```
+
+**Step 2.** `product-detail.html`에서 통째로 `<script>`와 `<style>`을 지우고, 대신 간단한 import만 남깁니다.
+
+```html
+<!-- 수정 전 (10~14줄) -->
+<script type="module" src="../main.js"></script>
+<script type="module">
+  import "../layout.js";
+  await new Promise((r) => setTimeout(r, 0));
+  import("../components/mobilemenu/menuAnimation.js");
+</script>
+
+<!-- 수정 후 -->
+<script type="module" src="../main.js"></script>
+<script type="module" src="../layout.js"></script>
+<script type="module" src="./productDetail.js"></script>
+```
+
+**Step 3.** HTML에 `id="product-thumbnail"`을 명시해서 JS에서 찾을 수 있게 합니다.
+
+```html
+<div class="product-thumbnail" id="product-thumbnail"></div>
+```
+
+기존의 `.mobile-slider-wrap`, `.desktop-thumb-box`, `.slider-dots` 관련 마크업은 전부 지우고, 이 빈 컨테이너 하나만 두면 캐러셀이 알아서 내용을 만들어냅니다.
+
+> **쉽게 말하면:** 그림과 그 그림을 설명하는 글을 한 장에 같이 그리는 대신, 그림 파일과 설명 파일을 따로 두는 거예요. 다음에 그림만 교체하고 싶을 때 설명 파일을 건드릴 필요가 없어집니다.
+
+---
+
+## 3-6. 상품상세 슬라이더를 `createImageCarousel`로 교체 (중요도: 중간)
+
+### 문제
+
+`product-detail.html` 396~443줄의 `sliderWrap` pointer 이벤트 처리와 `imageCarousel.js` 72~121줄이 거의 동일합니다.
+
+### 해결 방법
+
+3-5의 `renderProduct()`에서 이미 `createImageCarousel(images, { alt })`를 사용하고 있어요. 이 한 줄로 모바일/데스크탑 모두 처리되니, 기존의 아래 코드를 **전부 삭제**해야 합니다.
+
+- `product-detail.html`의 `mobile-slider-wrap`, `mobile-slider-track`, `slider-dots`, `desktop-thumb-box` 관련 HTML
+- `<style>` 안의 `.mobile-slider-*`, `.slider-dot*` CSS (3-1에서 이미 삭제됨)
+- `<script>` 안의 `ptrStartX`, `sliderWrap.addEventListener` 등 pointer 처리 전부
+- `desktopBox` 반복문
+
+> **쉽게 말하면:** 공용 화장실을 새로 만들어 놓고도 방마다 또 화장실을 짓는 것과 같아요. 공용을 쓰면 청소(유지보수)가 한 번만 필요합니다.
+
+---
+
+## 3-7. 유효성 검사 함수를 classList 기반으로 (중요도: 중간)
+
+### 문제
+
+`checkKoreanName.js`, `checkPassword.js`, `checkRequired.js`가 `style.borderColor`, `style.outlineColor`를 직접 조작합니다.
+
+### 해결 방법
+
+**Step 1.** `checkKoreanName.js`.
+
+```javascript
+// 수정 전 (src/components/login/checkKoreanName.js)
+export function checkKoreanName(inputId) {
+  const input = document.getElementById(inputId);
+  const koreanOnly = /^[가-힣]+$/;
+
+  if (!koreanOnly.test(input.value)) {
+    input.style.borderColor = "red";
+    return false;
+  }
+  input.style.borderColor = "";
+  return true;
+}
+
+// 수정 후
+export function checkKoreanName(inputId) {
+  const input = document.getElementById(inputId);
+  const koreanOnly = /^[가-힣]+$/;
+  const isValid = koreanOnly.test(input.value);
+
+  input.classList.toggle("border-red-500", !isValid);
+  return isValid;
+}
+```
+
+**Step 2.** `checkPassword.js`도 같은 패턴으로.
+
+```javascript
+// 수정 후
+export function checkPassword() {
+  const password = document.getElementById("passwordInput");
+  const passwordCheck = document.getElementById("passwordCheck");
+  const isMatch = password.value === passwordCheck.value;
+
+  passwordCheck.classList.toggle("border-red-500", !isMatch);
+  return isMatch;
+}
+```
+
+**Step 3.** `checkRequired.js`의 outline은 Tailwind의 `outline`/`ring` 유틸리티를 씁니다.
+
+```javascript
+// 수정 후
+export function checkRequired() {
+  const agreeTerms = document.getElementById("agreeTerms");
+  const agreeAge = document.getElementById("agreeAge");
+
+  agreeTerms.classList.toggle("ring-1", !agreeTerms.checked);
+  agreeTerms.classList.toggle("ring-red-500", !agreeTerms.checked);
+  if (!agreeTerms.checked) return false;
+
+  agreeAge.classList.toggle("ring-1", !agreeAge.checked);
+  agreeAge.classList.toggle("ring-red-500", !agreeAge.checked);
+  if (!agreeAge.checked) return false;
+
+  return true;
+}
+```
+
+> **쉽게 말하면:** "빨간 테두리"라는 상태를 **조명(style)** 대신 **스위치(class)** 로 껐다 켰다 하는 거예요. 스위치 하나만 토글하면 되니 코드가 짧고 테마 변경에도 강해집니다.
+
+---
+
+## 3-8. `handlerRegister.js`를 객체 인자로 호출 (중요도: 중간)
+
+### 문제
+
+`src/components/login/handlerRegister.js` 55번 줄이 7개의 위치 인자로 API를 부릅니다.
+
+### 해결 방법
+
+**Step 1.** `handlerRegister.js`의 호출부를 수정합니다.
+
+```javascript
+// 수정 전 (55줄)
+await postRegisterApi(email, pw, fn, ln, phone, address, addressDetail);
+
+// 수정 후
+await postRegisterApi({
+  email,
+  password: pw,
+  firstName: fn,
+  lastName: ln,
+  phone,
+  address,
+  addressDetail,
+});
+```
+
+**Step 2.** `src/components/API/register/postRegisterApi.js`의 시그니처도 함께 바꿉니다.
+
+```javascript
+// 수정 전 (예상)
+export async function postRegisterApi(email, password, firstName, lastName, phone, address, addressDetail) {
+  return await post("/user/register", {
+    email, password, firstName, lastName, phone, address, addressDetail,
+  });
+}
+
+// 수정 후
+export async function postRegisterApi({
+  email, password, firstName, lastName, phone, address, addressDetail,
+}) {
+  return await post("/user/register", {
+    email, password, firstName, lastName, phone, address, addressDetail,
+  });
+}
+```
+
+> **쉽게 말하면:** 택배를 보낼 때 "박스 순서대로 받는 분"이 아니라 "각 박스에 이름표"를 붙이는 거예요. 순서가 바뀌어도 이름표로 제대로 찾아갑니다.
+
+---
+
+## 3-9. 모바일 메뉴 공통화 (중요도: 중간)
+
+### 문제
+
+`register.html`, `profile.html`, `collection.html`에 모바일 메뉴가 복사되어 있습니다. 이전 리뷰에서도 지적된 장기 과제예요.
+
+### 해결 방법
+
+**Step 1.** `src/components/mobilemenu/mobileMenu.html`을 (없다면) 만듭니다.
+
+```html
+<!-- src/components/mobilemenu/mobileMenu.html -->
+<div
+  id="mobileMenu"
+  class="fixed opacity-0 pointer-events-none transition-all duration-500 top-0 z-49 left-0 bg-white w-screen h-full"
+>
+  <aside class="relative top-40 ml-5">
+    <nav>
+      <ul class="font-medium flex flex-col gap-2 mb-3">
+        <li class="menu-animate text-[22px]"><a class="w-max" href="/">선글라스</a></li>
+        <li class="menu-animate text-[22px]"><a class="w-max" href="/">안경</a></li>
+        <li class="menu-animate text-[22px]"><a class="w-max" href="/">컬렉션</a></li>
+      </ul>
+      <ul class="font-medium flex flex-col gap-2">
+        <li class="menu-animate text-[18px]"><a class="w-max" href="/">스토리</a></li>
+        <li class="menu-animate text-[18px]"><a class="w-max" href="/">서비스</a></li>
+      </ul>
+    </nav>
+    <!-- ... 기존 내용 그대로 ... -->
+  </aside>
+</div>
+```
+
+**Step 2.** `src/components/mobilemenu/loadMobileMenu.js`를 만듭니다.
+
+```javascript
+// src/components/mobilemenu/loadMobileMenu.js
+export async function loadMobileMenu(target = document.body) {
+  const res = await fetch("/src/components/mobilemenu/mobileMenu.html");
+  if (!res.ok) return;
+  const html = await res.text();
+  const tpl = document.createElement("template");
+  tpl.innerHTML = html.trim();
+  target.prepend(tpl.content.firstElementChild);
+}
+```
+
+**Step 3.** `layout.js`에서 호출합니다.
+
+```javascript
+// layout.js (예시)
+import { loadMobileMenu } from "./components/mobilemenu/loadMobileMenu.js";
+
+await loadHeader();
+await loadMobileMenu();   // 추가
+await loadFooter();
+```
+
+**Step 4.** `register.html`, `profile.html`, `collection.html`의 `<div id="mobileMenu">...</div>` 블록을 **통째로 삭제**합니다.
+
+> **쉽게 말하면:** 3개 교실에 같은 포스터를 따로 붙이는 대신, 학교 정문에 한 장만 붙여놓고 모든 학생이 지나가며 볼 수 있게 만드는 거예요. 포스터 내용이 바뀌면 한 장만 교체하면 됩니다.
+
+---
+
+## 3-10. `register.html`의 "걔정" 오타 수정 (중요도: 낮음)
+
+### 문제
+
+`src/components/login/register.html` 69번 줄.
+
+### 해결 방법
+
+**Step 1.** 한 글자 수정.
+
+```html
+<!-- 수정 전 -->
+아래 필드에 정보를 입력하여 걔정을 생성하고 특별한 서비스를
+만나보세요.
+
+<!-- 수정 후 -->
+아래 필드에 정보를 입력하여 계정을 생성하고 특별한 서비스를
+만나보세요.
+```
+
+---
+
+## 4-1. `addressSearch.js`의 `editAdress` 오타 정리 (참고 사항)
+
+"address"의 올바른 철자는 d가 2개(ad-**d**-ress)예요. 현재 `profile.html`의 id도 같은 오타를 쓰고 있어 맞물려서 동작하니 **두 곳을 동시에** 고치세요.
+
+**Step 1.** `src/components/profile/profile.html`에서 id를 수정.
+
+```html
+<!-- 수정 전 -->
+<input id="editAdress" ... />
+<input id="editAdressDetail" ... />
+
+<!-- 수정 후 -->
+<input id="editAddress" ... />
+<input id="editAddressDetail" ... />
+```
+
+**Step 2.** `src/components/login/addressSearch.js`도 함께 수정.
+
+```javascript
+// 수정 전 (7줄)
+bindAddressSearch("profileAddressSearchBtn", "editAdress", "editAdressDetail");
+
+// 수정 후
+bindAddressSearch("profileAddressSearchBtn", "editAddress", "editAddressDetail");
+```
+
+**Step 3.** 프로젝트 전체에서 `editAdress`를 검색해서 남은 참조가 없는지 확인.
+
+```bash
+grep -rn "editAdress" src/
+```
+
+---
+
+## 수정 우선순위 체크리스트
+
+| 순서 | 항목 | 난이도 | 예상 시간 |
+|------|------|--------|-----------|
+| 1 | 3-2. `<label for>` 수정 | 쉬움 | 5분 |
+| 2 | 3-4. `console.log` 삭제 | 쉬움 | 1분 |
+| 3 | 3-10. "걔정" 오타 | 쉬움 | 1분 |
+| 4 | 4-1. `editAdress` → `editAddress` | 쉬움 | 5분 |
+| 5 | 3-8. `handlerRegister.js` 7-args → 객체 | 보통 | 15분 |
+| 6 | 3-7. 유효성 검사 classList | 보통 | 20분 |
+| 7 | 3-3. `imageCarousel.js` 클래스화 | 보통 | 40분 |
+| 8 | 3-1. `product-detail.html` inline `<style>` 제거 | 도전 | 1시간 |
+| 9 | 3-5 + 3-6. `productDetail.js` 분리 + 캐러셀 재사용 | 도전 | 1.5시간 |
+| 10 | 3-9. 모바일 메뉴 공통화 | 도전 | 1시간 |
+
+> 한 번에 다 고치려 하지 마세요. 1~5번까지는 오늘 안에, 6~8번은 이번 주 내로, 9~10번은 다음 스프린트 초반에 리팩터링 PR로 묶어서 처리하는 걸 추천합니다. 응원할게요! 🙌


### PR DESCRIPTION
## Summary
- `593a51e..b3e699c` 범위 머지분에 대한 코드 리뷰 문서 2종 추가
  - [`docs/2026041409_리뷰.md`](../blob/docs/code-review-2026041409/docs/2026041409_%EB%A6%AC%EB%B7%B0.md)
  - [`docs/2026041409_리뷰_해결.md`](../blob/docs/code-review-2026041409/docs/2026041409_%EB%A6%AC%EB%B7%B0_%ED%95%B4%EA%B2%B0.md)
- 관점: **응집도 ↑ / 결합도 ↓**, CSS 최소화 + **TailwindCSS 우선**

## 리뷰 요약

| 구분 | 건수 |
|------|------|
| 심각(높음) | 4건 |
| 개선 권장(중간) | 6건 |
| 참고(낮음) | 3건 |

### 🔴 심각 (우선 수정)
1. `product-detail.html` — 약 150줄 inline `<style>` + 260줄 inline `<script>`. Tailwind 원칙 위반
2. `register.html` — `<label for="default-checkbox">`, `for="checked-checkbox"` 등 **존재하지 않는 id 참조**로 라벨 클릭이 동작하지 않음
3. `imageCarousel.js` — 전체 스타일이 `style.cssText` 문자열. 동적이 아닌 값까지 JS로 지정
4. `productCard.js:8` — `console.log(product.images[0])` 재발 (이전 리뷰 지적사항)

### 🟡 개선 권장
5. 상품 상세 페이지 슬라이더가 `imageCarousel.js`를 재사용하지 않고 같은 로직을 중복 구현
6. `handlerRegister.js` — 여전히 `postRegisterApi(email, pw, fn, ln, phone, address, addressDetail)` 7-args 위치 호출
7. `checkKoreanName`, `checkPassword`, `checkRequired` — `style.borderColor/outlineColor` 직접 조작 → Tailwind `classList.toggle`로 전환 필요
8. 모바일 메뉴가 `register.html`, `profile.html`, `collection.html`에 복붙 (이전 리뷰 미해결)
9. "걔정" 오타 (`register.html:69`)
10. 상품 상세 페이지 구조를 `createImageCarousel` 기반으로 통합

### 🟢 참고
11. `addressSearch.js`의 `editAdress` / `editAdressDetail` 오타
12. `colors.js`에 상품 데이터 1건만 있음
13. 상품 상세 하드코딩된 세부 정보/사이즈

## 잘한 점(칭찬)
- `checkPassword/checkKoreanName/checkRequired/formatPhoneNumber/addressSearch`를 독립 파일로 분리 — 응집도의 시작
- `putProfileApi({ firstName, lastName, phone })` 객체 분해 도입 — 이전 리뷰 반영 완료
- 이미지 캐러셀/색상 칩 컴포넌트 분리 시도
- 카카오 우편번호 API 연동 깔끔

## Test plan
- [ ] 리뷰 문서 2종 가독성 확인 (docs/ 폴더에서 마크다운 렌더링)
- [ ] 해결 가이드의 코드 예시가 복붙 가능한지 확인
- [ ] 이전 리뷰(`20260412_리뷰.md`)와의 연결(미해결/해결 항목) 정확성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)